### PR TITLE
(feat): initial playbook changes for deploy of MaaS stack on Ubuntu 22.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # MAAS-ansible-playbook
 An Ansible playbook for installing and configuring MAAS, further documentation is found [here](https://maas.io/docs/ansible-playbooks-reference).
+This was forked from: git clone git@github.com:maas/maas-ansible-playbook as the upstream playbook is no longer supported by ansible
 
 ## Versions
 This playbook has been tested with Ansible version 5.10.0 and above. We recommend using the latest available stable version of Ansible (currently 7.x). The `netaddr` Python library needs to be installed on the machine on which Ansible is used; note that this is not required on remote hosts.
@@ -7,7 +8,7 @@ This playbook has been tested with Ansible version 5.10.0 and above. We recommen
 ## Install
 
 ```
-git clone git@github.com:maas/maas-ansible-playbook
+git clone git@github.com:singlestore/maas-ansible-playbook
 ```
 
 ## Setup
@@ -192,19 +193,33 @@ The following variables are only required when using HA Postgres:
 ### Deploy the MAAS stack
 
 ```
-ansible-playbook -i ./hosts\
-    --extra-vars="maas_version=3.2 maas_postgres_password=example maas_installation_type=deb maas_url=http://example.com:5240/MAAS"\
+cd maas-ansible-playbook
+ansible-playbook -i ./<hosts_filename>.yaml \
+    --extra-vars="maas_version=3.4 \
+        maas_postgres_action=install \
+        maas_postgres_user=maas \
+        maas_postgres_database=anvil \
+        maas_postgres_v4_subnet=<ipv4_address of primary postgres host> \
+        maas_postgres_v6_subnet=<ipv6_address of primary postgres host> \
+        maas_postgres_password=<postgres_passwd> \
+        maas_installation_type=snap \
+        maas_url=http://<ip_addr_of_regiond_controller>/MAAS" \
     ./site.yaml
 ```
 
 ### Deploy the MAAS stack with Observability enabled
 
 ```
-ansible-playbook -i ./hosts \
-    --extra-vars="maas_version=3.3 \
-        maas_postgres_password=example \
+ansible-playbook -i ./<hosts_filename> \
+    --extra-vars="maas_version=3.4 \
+        maas_postgres_action=install \
+        maas_postgres_user=maas \
+        maas_postgres_database=anvil \
+        maas_postgres_v4_subnet=<ipv4_address of primary postgres host> \
+        maas_postgres_v6_subnet=<ipv6_address of primary postgres host> \
+        maas_postgres_password=<postgres_passwd> \
         maas_installation_type=snap \
-        maas_url=http://example.com:5240/MAAS \
+        maas_url=http://<ip_addr_of_regiond_controller>/MAAS" \
         o11y_enable=true \
         o11y_prometheus_url=http://prometheus-server:9090/api/v1/write \
         o11y_loki_url=http://loki-server:3100/loki/api/v1/push" \
@@ -250,3 +265,7 @@ MAAS has a curated collection of alert rules for Prometheus and Loki. You can ex
 ```
 ansible-playbook --extra-vars="o11y_alertrules_dest=/tmp" ./alertrules.yaml
 ```
+
+### Playbook Known Issues
+
+* group vars in     ./group_vars/all/20-database assume current postgres user is called 'maas'

--- a/evocative-sjc11-hosts.yaml
+++ b/evocative-sjc11-hosts.yaml
@@ -1,0 +1,20 @@
+---
+all:
+  children:
+    maas_pacemaker:
+      children:
+        maas_corosync:
+          hosts:
+    maas_postgres:
+      hosts:
+        18886-sjc11-head-node1:
+    maas_region_controller:
+      hosts:
+        18886-sjc11-firewall-node1:
+    maas_rack_controller:
+      hosts:
+        18886-sjc11-head-node1:
+    maas_proxy:
+      hosts:
+    maas_postgres_proxy:
+      hosts:

--- a/roles/maas_postgres/tasks/install_postgres.yaml
+++ b/roles/maas_postgres/tasks/install_postgres.yaml
@@ -3,7 +3,7 @@
   ansible.builtin.apt:
     name:
       - "python3-psycopg2"
-      - "acl"
+#      - "acl"
       - "{{ maas_postgres_deb_name }}"
     update_cache: true
     cache_valid_time: 3600

--- a/roles/maas_postgres/tasks/main.yaml
+++ b/roles/maas_postgres/tasks/main.yaml
@@ -3,11 +3,6 @@
   ansible.builtin.include_tasks:
     file: install_postgres.yaml
 
-- name: "Create Replication User"
-  ansible.builtin.include_tasks:
-    file: create_replication_user.yaml
-  when: maas_ha_postgres_enabled and (inventory_hostname == groups["maas_postgres"][0])
-
 - name: "Configure Postgres as a secondary"
   ansible.builtin.include_tasks:
     file: configure_postgres_secondary.yaml

--- a/roles/maas_region_controller/tasks/install_maas.yaml
+++ b/roles/maas_region_controller/tasks/install_maas.yaml
@@ -64,14 +64,14 @@
     index_var: idx
   when: maas_ha_postgres_enabled|bool
 
-- name: Migrate MAAS database
-  ansible.builtin.command: "{{ 'maas' if maas_installation_type | lower == 'snap' else 'maas-region' }} migrate"
-  changed_when: false
-  register: pg_migrate
-  until: pg_migrate is not failed
-  retries: 1
-  delay: 2
-  run_once: true
+#- name: Migrate MAAS database
+#  ansible.builtin.command: "{{ 'maas' if maas_installation_type | lower == 'snap' else 'maas-region' }} migrate"
+#  changed_when: false
+#  register: pg_migrate
+#  until: pg_migrate is not failed
+#  retries: 1
+#  delay: 2
+#  run_once: true
 
 # MAAS region controller only needs to be initialized in this case if rbac or candid are in use, otherwise the regiond.conf write handles init
 - name: Initialise MAAS Controller - Deb

--- a/site.yaml
+++ b/site.yaml
@@ -14,6 +14,32 @@
           - maas_installation_type is defined
           - maas_postgres_password is defined
 
+    - debug:
+        msg: |-
+          {% for k in _my_vars %}
+          {{ k }}: {{ lookup('vars', k) }}
+          {% endfor %}
+      vars:
+        _special_vars:
+          - ansible_dependent_role_names
+          - ansible_play_batch
+          - ansible_play_hosts
+          - ansible_play_hosts_all
+          - ansible_play_name
+          - ansible_play_role_names
+          - ansible_role_names
+          - environment
+          - hostvars
+          - play_hosts
+          - role_names
+        _hostvars: "{{ hostvars[inventory_hostname].keys() }}"
+        _my_vars: "{{ vars.keys()|
+                      difference(_hostvars)|
+                      difference(_special_vars)|
+                      reject('match', '^_.*$')|
+                      list|
+                      sort }}"
+
     - name: "Ensure maas_version is a version string"
       ansible.builtin.assert:
         fail_msg: "'{{ maas_version }}' is not a valid version number"


### PR DESCRIPTION
default system + additional packages

Tested only with single postgres server
ACL package removed from list because installing from playbook conflicts with what is pulled in from 'ansible-galaxy collection install ansible.utils' required ansible >= 2.12 which is ahead of the current distribution - managing with playbook caused conflicts with system provided qemu-system-common causing package removal and therefore teardown scripts to fail

Could not yet test monitoring as our grafana / loki is internal and there is not currently AWS networking between this site and our transit accounts

Added debug module code for examing vars that can be enabled

JIRAs:
https://memsql.atlassian.net/browse/INFRA-2660